### PR TITLE
[FIX] split MRIQC invocations

### DIFF
--- a/invocations/mriqc-0.14.2_bold_invocation.json
+++ b/invocations/mriqc-0.14.2_bold_invocation.json
@@ -6,6 +6,7 @@
 		"fd_thres":0.5,
 		"verbose_count":"-v",
 		"verbose_reports":true,
-		"no_sub":true
+		"no_sub":true,
+		"modalities":["bold"]
 
 }

--- a/invocations/mriqc-0.14.2_t1w_invocation.json
+++ b/invocations/mriqc-0.14.2_t1w_invocation.json
@@ -4,6 +4,7 @@
 		"output_dir":"/output",
 		"n_procs":4,
 		"fd_thres":0.5,
+		"modalities":["T1w"],
 		"verbose_count":"-v",
 		"verbose_reports":true,
 		"no_sub":true


### PR DESCRIPTION
Have separate workflows for BOLD/T1w/all for cases in which issues arise due to specific modalities.