### PR TITLE
add syn-sdc in absence of fieldmaps or topup

### DIFF
--- a/invocations/fmriprep-1.5.8_invocation.json
+++ b/invocations/fmriprep-1.5.8_invocation.json
@@ -8,5 +8,6 @@
 	"omp_nthreads": 2,
 	"verbosity": "-vv",
 	"use_aroma": true,
+	"use_syn_sdc":true,
         "output_spaces": ["T1w", "MNI152NLin2009cAsym", "fsaverage", "fsaverage5"]
 }


### PR DESCRIPTION
use-syn-sdc when fieldmaps/topup not found by default